### PR TITLE
fix vanilla bug(?) where sprites in OpenGL are culled strangely when looking straight up or down

### DIFF
--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -4725,8 +4725,6 @@ static void HWR_ProjectSprite(mobj_t *thing)
 			if (md2->notfound || md2->scale < 0.0f)
 				return;
 		}
-		else
-			return;
 	}
 
 	// The above can stay as it works for cutting sprites that are too close


### PR DESCRIPTION
vanilla behavior (with `gr_spritebillboarding 1` for easier demonstration)
![image](https://github.com/user-attachments/assets/8f823782-3523-4c2e-a32d-0df50f402226)
![image](https://github.com/user-attachments/assets/ad3dadfb-4c7f-4840-9936-1a816e1cd0db)

fixed behavior
![image](https://github.com/user-attachments/assets/0b138f33-7ef5-43fc-813b-623fa9cbaaac)
![image](https://github.com/user-attachments/assets/b23c83ae-7510-4994-91a4-31a46e6d9ad6)
